### PR TITLE
remove travis table from index

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -64,6 +64,7 @@ $(function() {
 <div class="title">BitShares Core </div>  </div>
 </div><!--header-->
 <div class="contents">
+<div class="textblock">
 <ul>
 <li><a href="#getting-started">Getting Started</a></li>
 <li><a href="#support">Support</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -64,13 +64,6 @@ $(function() {
 <div class="title">BitShares Core </div>  </div>
 </div><!--header-->
 <div class="contents">
-<div class="textblock"><p><a href="https://travis-ci.org/bitshares/bitshares-core/branches">Build Status</a>:</p>
-<table class="doxtable">
-<tr>
-<th><code>master</code> </th><th><code>develop</code> </th><th><code>hardfork</code> </th><th><code>testnet</code> </th><th><code>bitshares-fc</code>  </th></tr>
-<tr>
-<td><a href="https://travis-ci.org/bitshares/bitshares-core"></a> </td><td><a href="https://travis-ci.org/bitshares/bitshares-core"></a> </td><td><a href="https://travis-ci.org/bitshares/bitshares-core"></a> </td><td><a href="https://travis-ci.org/bitshares/bitshares-core"></a> </td><td><a href="https://travis-ci.org/bitshares/bitshares-fc"></a> </td></tr>
-</table>
 <ul>
 <li><a href="#getting-started">Getting Started</a></li>
 <li><a href="#support">Support</a></li>


### PR DESCRIPTION
I forgot the remove the travis table from the main page as it do not display correctly in an html page. This pull removes that. 